### PR TITLE
Use macro for boringssl addition

### DIFF
--- a/src/lib/crypto/openssl/enc_provider/aes.c
+++ b/src/lib/crypto/openssl/enc_provider/aes.c
@@ -127,6 +127,7 @@ cbc_decr(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
 }
 
 
+#if USE_BORINGSSL
 /** The CTS mode is not implemented in BoringSSL.
   * So, copy the implementation from OpenSSL here.
   */
@@ -302,7 +303,7 @@ size_t CRYPTO_cts128_decrypt_block(const unsigned char *in,
 
     return 16 + len + residue;
 }
-
+#endif
 
 static krb5_error_code
 cts_encr(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
@@ -479,3 +480,4 @@ const struct krb5_enc_provider krb5int_enc_aes256 = {
     krb5int_aes_init_state,
     krb5int_default_free_state
 };
+


### PR DESCRIPTION
This should not effect anything as the macro is defined when boringSSL is used during the build. It will also avoid having to include a copy of `aes.c` in `krb5-cmake`. This would need to be kept up to date and broke recently due to changes. 
After this PR is merged, i will issue a submodule update against main clickhouse and remove 
```
if (ENABLE_OPENSSL OR ENABLE_OPENSSL_DYNAMIC)
   list(REMOVE_ITEM ALL_SRCS "${KRB5_SOURCE_DIR}/lib/crypto/openssl/enc_provider/aes.c")
   list(APPEND ALL_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/aes.c")
endif ()
```
from `krb5-cmake/CMakeLists.txt`