### PR TITLE
Ensure array count consistency in kadm5 RPC

### DIFF
--- a/src/lib/kadm5/kadm_rpc_xdr.c
+++ b/src/lib/kadm5/kadm_rpc_xdr.c
@@ -390,6 +390,7 @@ _xdr_kadm5_principal_ent_rec(XDR *xdrs, kadm5_principal_ent_rec *objp,
 			     int v)
 {
 	unsigned int n;
+	bool_t r;
 
 	if (!xdr_krb5_principal(xdrs, &objp->principal)) {
 		return (FALSE);
@@ -443,6 +444,9 @@ _xdr_kadm5_principal_ent_rec(XDR *xdrs, kadm5_principal_ent_rec *objp,
 	if (!xdr_krb5_int16(xdrs, &objp->n_key_data)) {
 		return (FALSE);
 	}
+	if (xdrs->x_op == XDR_DECODE && objp->n_key_data < 0) {
+		return (FALSE);
+	}
 	if (!xdr_krb5_int16(xdrs, &objp->n_tl_data)) {
 		return (FALSE);
 	}
@@ -451,9 +455,10 @@ _xdr_kadm5_principal_ent_rec(XDR *xdrs, kadm5_principal_ent_rec *objp,
 		return FALSE;
 	}
 	n = objp->n_key_data;
-	if (!xdr_array(xdrs, (caddr_t *) &objp->key_data,
-		       &n, ~0, sizeof(krb5_key_data),
-		       xdr_krb5_key_data_nocontents)) {
+	r = xdr_array(xdrs, (caddr_t *) &objp->key_data, &n, objp->n_key_data,
+		      sizeof(krb5_key_data), xdr_krb5_key_data_nocontents);
+	objp->n_key_data = n;
+	if (!r) {
 		return (FALSE);
 	}
 


### PR DESCRIPTION
- Reported by IBM, see https://www.cve.org/CVERecord?id=CVE-2023-36054
- Corresponding PR in ClickHouse repository: https://github.com/ClickHouse/krb5/pull/12

---

In _xdr_kadm5_principal_ent_rec(), ensure that n_key_data matches the key_data array count when decoding.  Otherwise when the structure is later freed, xdr_array() could iterate over the wrong number of elements, either leaking some memory or freeing uninitialized pointers.  Reported by Robert Morris.

CVE-2023-36054:

An authenticated attacker can cause a kadmind process to crash by freeing uninitialized pointers.  Remote code execution is unlikely. An attacker with control of a kadmin server can cause a kadmin client to crash by freeing uninitialized pointers.

ticket: 9099 (new)
tags: pullup
target_version: 1.21-next
target_version: 1.20-next